### PR TITLE
Lyra level 3

### DIFF
--- a/sunpy/lightcurve/lightcurve.py
+++ b/sunpy/lightcurve/lightcurve.py
@@ -103,7 +103,7 @@ for compatability with map, please use meta instead""", Warning)
     @classmethod
     def from_range(cls, start, end, **kwargs):
         '''Called by Conditional Dispatch object when start and end time are passed as input to create method.'''
-        url = cls._get_url_for_date_range(parse_time(start), parse_time(end))
+        url = cls._get_url_for_date_range(parse_time(start), parse_time(end), **kwargs)
         filepath = cls._download(
             url, kwargs, 
             err = "Unable to download data for specified date range"
@@ -115,7 +115,7 @@ for compatability with map, please use meta instead""", Warning)
     @classmethod
     def from_timerange(cls, timerange, **kwargs):
         '''Called by Conditional Dispatch object when time range is passed as input to create method.'''
-        url = cls._get_url_for_date_range(timerange)
+        url = cls._get_url_for_date_range(timerange, **kwargs)
         filepath = cls._download(
             url, kwargs,
             err = "Unable to download data for specified date range"

--- a/sunpy/lightcurve/sources/lyra.py
+++ b/sunpy/lightcurve/sources/lyra.py
@@ -118,8 +118,17 @@ class LYRALightCurve(LightCurve):
         start = parse_time(start_str)
         #end = datetime.datetime.strptime(end_str, '%Y-%m-%dT%H:%M:%S.%f')
 
-        # First column are times
-        times = [start + datetime.timedelta(0, int(n)) for n in fits_record.field(0)]
+        # First column are times.  For level 2 data, the units are [s].
+        # For level 3 data, the units are [min]
+        if hdulist[1].header['TUNIT1'] == 's':
+            times = [start + datetime.timedelta(seconds=int(n))
+                     for n in fits_record.field(0)]
+        elif hdulist[1].header['TUNIT1'] == 'MIN':
+            times = [start + datetime.timedelta(minutes=int(n))
+                     for n in fits_record.field(0)]
+        else:
+            raise ValueError("Time unit in LYRA fits file not recognised.  "
+                             "Value = {0}".format(hdulist[1].header['TUNIT1']))
 
         # Rest of columns are the data
         table = {}


### PR DESCRIPTION
Hi @gunner272.  Here is a little fix for ensuring that the LYRALightCurve object correctly interprets the times in the level 3 fits files.  The level 3 fits files have times in minutes, not seconds like in the standard level 2 fits.  This means that the LYRALightCurve object was interpretting the level 3 measurements as every second instead of every minute.  This change fixes that.
